### PR TITLE
Header spacing

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -13,7 +13,7 @@ body {
 }
 
 p {
-    margin: 1em 0;
+    margin: 1.2em 0;
 }
 
 .sidenav {
@@ -24,7 +24,7 @@ p {
     max-width: 840px;
     width: 100%;
     margin: 0 auto;
-    padding-top: 40px;
+    padding-top: 5px;
 }
 
 .ui.menu.main > .menu {
@@ -124,4 +124,12 @@ td img.icon {
   .ui.menu.mobile {
       display: block;
   }
+}
+.main-title{
+  padding: 12px 0px;
+  font-size: 42px;
+}
+
+.submit-new-company{
+  padding-top: 10px !important;
 }

--- a/index.html
+++ b/index.html
@@ -16,10 +16,10 @@ hash: DiversityData
 
             <div class="banner ui icon header">
                 <img src="img/logo.png" />
-                <h2>Open Diversity Data</h2>
+                <h2 class="main-title">Open Diversity Data</h2>
                 <div class="sub header">Companies already collect about their employee demographics. Let's ask them to publish it. Open diversity data will make it easier for everyone to better understand the diversity landscape and work toward solutions.
                 </div>
-                <div class="sub header">
+                <div class="sub header submit-new-company">
                     (Don't see a company you're interested in? Add it by <a href="https://github.com/doubleunion/opendiversitydata">submitting a pull request or issue</a>.)
                 </div>
             </div>


### PR DESCRIPTION
Remove some of the excess space at the top above the logo, bump up the title's font size, add spacing around the header and paragraph elements. 

![screen shot 2014-06-19 at 1 52 58 pm](https://cloud.githubusercontent.com/assets/984213/3333461/cd0be61a-f7f3-11e3-9959-a782409f3e30.png)
