### PR TITLE
Refer to correct variable for documentation links.

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,8 +64,8 @@ hash: DiversityData
                                     </td>
 
                                     <td class="positive icon">
-                                        {% if company.doc %}
-                                        <a href="{{ company.doc }}"><i class="external url link large icon"></i></a>
+                                        {% if company.documentation %}
+                                        <a href="{{ company.documentation }}"><i class="external url link large icon"></i></a>
                                         {% endif %}
                                     </td>
 


### PR DESCRIPTION
Links display correctly. We were just using company.doc instead of company.documentation. Easy fix once I realized!
