### PR TITLE
Remove horizontal scrolling on mobile displays

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -136,3 +136,15 @@ td img.icon {
 .submit-new-company{
   padding-top: 10px !important;
 }
+
+@media (max-width: 360px) {
+  .ui.grid {
+    font-size: 0.7em !important;
+    margin: 0 !important;
+  }
+
+  .ui.grid>.column,
+  .ui.grid>.row>.column {
+    font-size: 1em !important;
+  }
+}


### PR DESCRIPTION
Corrects https://github.com/doubleunion/opendiversitydata/issues/20 (I hope).

Not sure what the purpose of all the rems was, or why the slightly odd margin on the table, but this change seems to make the table fit within the constraints of my Nexus 5. I recommend testing this before going live with it, since I haven't done any testing outside of Chrome.
