### PR TITLE
Fix broken LinkedIn URL.

### DIFF
--- a/_data/tech.yml
+++ b/_data/tech.yml
@@ -10,7 +10,7 @@ companies:
     status: No
 
   - name: LinkedIn
-    url: https://www.company.com/
+    url: https://www.linkedin.com/
     twitter: LinkedIn
     img: linkedin.jpeg
     diversitydata: Yes


### PR DESCRIPTION
This patch just replaces https://www.company.com/ with https://www.linkedin.com/
