### PR TITLE
Add a link to GitHub 2016 diversity data

### DIFF
--- a/_data/tech.yml
+++ b/_data/tech.yml
@@ -152,11 +152,11 @@ companies:
     url: https://github.com/
     twitter: Github
     img: github.jpeg
-    diversitydata: No
+    diversitydata: Yes
     eeo-1: No
-    documentation: <link to company's diversity data>
-    date-updated: YYYY
-    status: No
+    documentation: https://diversity.github.com/
+    date-updated: 2016
+    status: Yes
 
   - name: Groupon
     url: https://www.groupon.com/


### PR DESCRIPTION
This Pull Request adds a link to the diversity data that GitHub released in May of 2016.

There is more information available about this release at: https://github.com/blog/2176-diversity-and-inclusion-at-github
